### PR TITLE
Support zoom on local file:// pages

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,8 @@
         {
             "matches": [
                 "http://*/*",
-                "https://*/*"
+                "https://*/*",
+                "file:///*"
             ],
             "css": [],
             "js": [
@@ -25,7 +26,8 @@
         {
             "matches": [
                 "http://*/*",
-                "https://*/*"
+                "https://*/*",
+                "file:///*"
             ],
             "resources": [
                 "js/popup.js",


### PR DESCRIPTION
## Problem

Ctrl Zoom does not work on local HTML files opened via `file://`. The content script is only injected on `http` and `https` pages because the manifest match patterns are limited to those schemes.

## Fix

Add `file:///*` to the `matches` arrays of both `content_scripts` and `web_accessible_resources`.

```json
"matches": [ "http://*/*", "https://*/*", "file:///*" ]
```

With this in place, users who enable "Allow access to file URLs" for the extension can zoom on local HTML files as well. The toggle does not even appear in the extension details until a `file://` pattern is present in the manifest, so this change is a prerequisite for it.

## Notes

- No new permissions are requested. `file://` access still requires the user to opt in via the per extension "Allow access to file URLs" toggle, so this is not a privacy or security expansion by default.
- Behaviour on `http`/`https` pages is unchanged.

## Test

1. Load the extension unpacked.
2. Open the extension details and enable "Allow access to file URLs".
3. Open any local `.html` file and confirm Ctrl + touchpad scroll zooms as on a normal website.