### PR TITLE
Throttle browser-zoom path to prevent browser freeze

### DIFF
--- a/js/contentScript.js
+++ b/js/contentScript.js
@@ -42,6 +42,8 @@
     }
 
     function sendZoom(message) {
+        if (!zoom.allowNext(values.minDelay))
+            return;
         values.useBrowserZoom
             ? chrome.runtime.sendMessage({ msgKind: zoom.msgKind, ...message })
             : handleZoom(message);
@@ -78,18 +80,16 @@
 
     function setZoom(ratio) {
         setTimeout(() => {
-            if (zoom.allowNext(values.minDelay)) {
-                if (!values.useBrowserZoom && values.showPopup)
-                    popUp.showPopup(ratio, (r) => getZoom(r), (r) => setZoom(r), () => reset(), values.showPopupTime);
+            if (!values.useBrowserZoom && values.showPopup)
+                popUp.showPopup(ratio, (r) => getZoom(r), (r) => setZoom(r), () => reset(), values.showPopupTime);
 
-                document.body.style.zoom = ratio;
-                if (!values.rememberZoom)
-                    return localStorage.removeItem(`${zoom.getId()}:ext:zoom`);
+            document.body.style.zoom = ratio;
+            if (!values.rememberZoom)
+                return localStorage.removeItem(`${zoom.getId()}:ext:zoom`);
 
-                (ratio == 1)
-                    ? localStorage.removeItem(`${zoom.getId()}:ext:zoom`)
-                    : localStorage.setItem(`${zoom.getId()}:ext:zoom`, ratio);
-            }
+            (ratio == 1)
+                ? localStorage.removeItem(`${zoom.getId()}:ext:zoom`)
+                : localStorage.setItem(`${zoom.getId()}:ext:zoom`, ratio);
         }, 0);
     }
 


### PR DESCRIPTION
## Problem

After zooming repeatedly (especially via trackpad pinch), zooming stops responding and the whole browser eventually freezes.

## Cause

`CtrlZoom.allowNext()` implements a `minDelay` debounce that is meant to rate limit zoom steps. In `contentScript.js` that gate is only applied on the CSS-zoom path, inside `setZoom()`.

With the default configuration (`useBrowserZoom: true`), zooming does not go through `setZoom()`. It goes through `sendZoom()`, which calls `chrome.runtime.sendMessage` on **every** wheel event with no rate limiting:

```js
function sendZoom(message) {
    values.useBrowserZoom
        ? chrome.runtime.sendMessage({ msgKind: zoom.msgKind, ...message })  // not throttled
        : handleZoom(message);                                              // throttled inside setZoom
}
```

The background worker then calls `chrome.tabs.setZoom` for each message. A trackpad pinch generates dozens of `wheel` events per second, so this floods the browser process with `tabs.setZoom` IPC calls. The backlog builds up across a session and the browser becomes unresponsive.

## Fix

Move the `allowNext()` gate from `setZoom()` into `sendZoom()`, so the existing `minDelay` debounce applies to both the browser-zoom and CSS-zoom paths. `setZoom()` no longer needs its own gate because every flooding caller now reaches it through the throttled `sendZoom()`. Direct callers (`reset()`, popup buttons) are click/one-shot driven and are intentionally left ungated.

No behaviour change for normal use: zoom steps are simply capped at the `minDelay` rate (default 100 ms) that the extension already intended.

## Other observations (not fixed here, kept out of scope)

- `background.js` keeps `currentRatio` as a single global shared across all tabs, so switching tabs can make the `ratio == currentRatio` comparison skip a valid zoom step.
- `e.wheelDelta` is deprecated; the `minimumScroll` threshold relies on it.

## Test

1. Load the extension unpacked.
2. With the default settings (`useBrowserZoom` on), pinch-zoom rapidly and repeatedly for a while.
3. Confirm zooming keeps responding and the browser stays smooth.